### PR TITLE
Support the newer versions of node

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,3 +54,6 @@ in queue manager code. Added makedoc script to generate JSDoc output.
 
 06 Jun 2018
 * Version 0.7.1 : Use smaller base image for container. Keep runmqsc in redist package
+
+14 Jun 2018
+* Version 0.8.0 : Use fastcall instead of node-ffi in order to support the newer versions of NodeJS

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -57,7 +57,7 @@
 
 // Import external packages for handling structures and calling C libraries
 var ref = require('ref');
-var ffi = require('ffi');
+var fastcall = require('fastcall');
 var StructType = require('ref-struct');
 var ArrayType = require('ref-array');
 
@@ -161,7 +161,7 @@ function loadLib(dir,name) {
     libname = name;
   }
   try {
-    libmqm = ffi.Library(libname, {
+    libmqm = fastcall.Library(libname, {
       'MQCONNX': ['void', ['pointer', MQT.PHCONN, MQT.PCNO, MQT.PLONG, MQT.PLONG]],
       'MQDISC' : ['void', [MQT.PHCONN, MQT.PLONG, MQT.PLONG]],
       'MQOPEN' : ['void', [MQT.HCONN, MQT.POD,MQT.LONG,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]],

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -162,7 +162,7 @@ function loadLib(dir,name) {
     libname = name;
   }
   try {
-    libmqm = new ffi.Library(libname, ({
+    libmqm = new ffi.Library(libname, {
       'MQCONNX': ['void', ['pointer', MQT.PHCONN, MQT.PCNO, MQT.PLONG, MQT.PLONG]],
       'MQDISC' : ['void', [MQT.PHCONN, MQT.PLONG, MQT.PLONG]],
       'MQOPEN' : ['void', [MQT.HCONN, MQT.POD,MQT.LONG,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]],

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -199,7 +199,7 @@ function loadLibMulti() {
   var err;
 
   if (process.platform === 'win32') {
-    l='mqm';
+    l='mqm.dll';
     err = loadLib(null,l);
     if (err) {
        err = loadLib("c:\\Program Files\\IBM\\MQ\\bin64",l);
@@ -219,7 +219,7 @@ function loadLibMulti() {
       err = loadLib(p,l);
     }
   } else {
-    l='libmqm_r';
+    l='libmqm_r.so';
     err = loadLib(null,l);
 
     if (err) {

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -161,30 +161,29 @@ function loadLib(dir,name) {
     libname = name;
   }
   try {
-    libmqm = fastcall.Library(libname, {
-      'MQCONNX': ['void', ['pointer', MQT.PHCONN, MQT.PCNO, MQT.PLONG, MQT.PLONG]],
-      'MQDISC' : ['void', [MQT.PHCONN, MQT.PLONG, MQT.PLONG]],
-      'MQOPEN' : ['void', [MQT.HCONN, MQT.POD,MQT.LONG,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]],
-      'MQCLOSE': ['void', [MQT.HCONN, MQT.PHOBJ,MQT.LONG,MQT.PLONG,MQT.PLONG]],
-      'MQSTAT' : ['void', [MQT.HCONN, MQT.LONG, MQT.PSTS, MQT.PLONG,MQT.PLONG]],
-      'MQBEGIN': ['void', [MQT.HCONN, 'pointer', MQT.PLONG, MQT.PLONG]],
-      'MQCMIT' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]],
-      'MQBACK' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]],
-      'MQPUT'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD,MQT.PPMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]],
-      'MQPUT1' : ['void', [MQT.HCONN, MQT.POD, MQT.PMD, MQT.PPMO, MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]],
-      'MQGET'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD, MQT.PGMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG, MQT.PLONG]],
-      'MQSUB'  : ['void', [MQT.HCONN, MQT.PSD, MQT.PHOBJ,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]],
-      'MQSUBRQ': ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG,MQT.PSRO,MQT.PLONG,MQT.PLONG]],
-      //'MQCTL'  : ['void', [MQT.HCONN, MQT.LONG, MQT.PCTLO,MQT.PLONG,MQT.PLONG]],
-      //'MQCB'   : ['void', [MQT.HCONN, MQT.LONG, MQT.PCBD,MQT.HOBJ,MQT.PMD,MQT.PGMO,MQT.PLONG,MQT.PLONG]],
-      'MQINQ'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]],
-      'MQSET'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]],
-      'MQCRTMH' : ['void', [MQT.HCONN, MQT.PCMHO, MQT.PHMSG, MQT.PLONG, MQT.PLONG]],
-      'MQDLTMH' : ['void', [MQT.HCONN, MQT.PHMSG, MQT.PDMHO, MQT.PLONG, MQT.PLONG]],
-      'MQSETMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PSMPO, MQT.PCHARV, MQT.PPD, MQT.LONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG]],
-      'MQINQMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PIMPO, MQT.PCHARV, MQT.PPD, MQT.PLONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG, MQT.PLONG]],
-      'MQDLTMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PDMPO, MQT.PCHARV, MQT.PLONG, MQT.PLONG]],
-    });
+    libmqm = new fastcall.Library(libname)
+      .function({ 'MQCONNX': ['void', ['pointer', MQT.PHCONN, MQT.PCNO, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQDISC' : ['void', [MQT.PHCONN, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQOPEN' : ['void', [MQT.HCONN, MQT.POD,MQT.LONG,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQCLOSE': ['void', [MQT.HCONN, MQT.PHOBJ,MQT.LONG,MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQSTAT' : ['void', [MQT.HCONN, MQT.LONG, MQT.PSTS, MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQBEGIN': ['void', [MQT.HCONN, 'pointer', MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQCMIT' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQBACK' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQPUT'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD,MQT.PPMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQPUT1' : ['void', [MQT.HCONN, MQT.POD, MQT.PMD, MQT.PPMO, MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQGET'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD, MQT.PGMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQSUB'  : ['void', [MQT.HCONN, MQT.PSD, MQT.PHOBJ,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQSUBRQ': ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG,MQT.PSRO,MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQINQ'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQSET'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]] })
+      .function({ 'MQCRTMH' : ['void', [MQT.HCONN, MQT.PCMHO, MQT.PHMSG, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQDLTMH' : ['void', [MQT.HCONN, MQT.PHMSG, MQT.PDMHO, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQSETMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PSMPO, MQT.PCHARV, MQT.PPD, MQT.LONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQINQMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PIMPO, MQT.PCHARV, MQT.PPD, MQT.PLONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG, MQT.PLONG]] })
+      .function({ 'MQDLTMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PDMPO, MQT.PCHARV, MQT.PLONG, MQT.PLONG]] });
+      // .function('MQCTL'  : ['void', [MQT.HCONN, MQT.LONG, MQT.PCTLO,MQT.PLONG,MQT.PLONG]])
+      // .function('MQCB'   : ['void', [MQT.HCONN, MQT.LONG, MQT.PCBD,MQT.HOBJ,MQT.PMD,MQT.PGMO,MQT.PLONG,MQT.PLONG]])
     return null;
   } catch(err) {
     return err;

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -58,6 +58,7 @@
 // Import external packages for handling structures and calling C libraries
 var ref = require('ref');
 var fastcall = require('fastcall');
+var ffi = fastcall.ffi;
 var StructType = require('ref-struct');
 var ArrayType = require('ref-array');
 
@@ -161,29 +162,30 @@ function loadLib(dir,name) {
     libname = name;
   }
   try {
-    libmqm = new fastcall.Library(libname)
-      .function({ 'MQCONNX': ['void', ['pointer', MQT.PHCONN, MQT.PCNO, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQDISC' : ['void', [MQT.PHCONN, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQOPEN' : ['void', [MQT.HCONN, MQT.POD,MQT.LONG,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQCLOSE': ['void', [MQT.HCONN, MQT.PHOBJ,MQT.LONG,MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQSTAT' : ['void', [MQT.HCONN, MQT.LONG, MQT.PSTS, MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQBEGIN': ['void', [MQT.HCONN, 'pointer', MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQCMIT' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQBACK' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQPUT'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD,MQT.PPMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQPUT1' : ['void', [MQT.HCONN, MQT.POD, MQT.PMD, MQT.PPMO, MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQGET'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD, MQT.PGMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQSUB'  : ['void', [MQT.HCONN, MQT.PSD, MQT.PHOBJ,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQSUBRQ': ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG,MQT.PSRO,MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQINQ'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQSET'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]] })
-      .function({ 'MQCRTMH' : ['void', [MQT.HCONN, MQT.PCMHO, MQT.PHMSG, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQDLTMH' : ['void', [MQT.HCONN, MQT.PHMSG, MQT.PDMHO, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQSETMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PSMPO, MQT.PCHARV, MQT.PPD, MQT.LONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQINQMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PIMPO, MQT.PCHARV, MQT.PPD, MQT.PLONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG, MQT.PLONG]] })
-      .function({ 'MQDLTMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PDMPO, MQT.PCHARV, MQT.PLONG, MQT.PLONG]] });
-      // .function('MQCTL'  : ['void', [MQT.HCONN, MQT.LONG, MQT.PCTLO,MQT.PLONG,MQT.PLONG]])
-      // .function('MQCB'   : ['void', [MQT.HCONN, MQT.LONG, MQT.PCBD,MQT.HOBJ,MQT.PMD,MQT.PGMO,MQT.PLONG,MQT.PLONG]])
+    libmqm = new ffi.Library(libname, ({
+      'MQCONNX': ['void', ['pointer', MQT.PHCONN, MQT.PCNO, MQT.PLONG, MQT.PLONG]],
+      'MQDISC' : ['void', [MQT.PHCONN, MQT.PLONG, MQT.PLONG]],
+      'MQOPEN' : ['void', [MQT.HCONN, MQT.POD,MQT.LONG,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]],
+      'MQCLOSE': ['void', [MQT.HCONN, MQT.PHOBJ,MQT.LONG,MQT.PLONG,MQT.PLONG]],
+      'MQSTAT' : ['void', [MQT.HCONN, MQT.LONG, MQT.PSTS, MQT.PLONG,MQT.PLONG]],
+      'MQBEGIN': ['void', [MQT.HCONN, 'pointer', MQT.PLONG, MQT.PLONG]],
+      'MQCMIT' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]],
+      'MQBACK' : ['void', [MQT.HCONN, MQT.PLONG, MQT.PLONG]],
+      'MQPUT'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD,MQT.PPMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]],
+      'MQPUT1' : ['void', [MQT.HCONN, MQT.POD, MQT.PMD, MQT.PPMO, MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG]],
+      'MQGET'  : ['void', [MQT.HCONN, MQT.HOBJ,MQT.PMD, MQT.PGMO,MQT.LONG, 'pointer',MQT.PLONG, MQT.PLONG, MQT.PLONG]],
+      'MQSUB'  : ['void', [MQT.HCONN, MQT.PSD, MQT.PHOBJ,MQT.PHOBJ,MQT.PLONG,MQT.PLONG]],
+      'MQSUBRQ': ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG,MQT.PSRO,MQT.PLONG,MQT.PLONG]],
+      // 'MQCTL'  : ['void', [MQT.HCONN, MQT.LONG, MQT.PCTLO,MQT.PLONG,MQT.PLONG]],
+      // 'MQCB'   : ['void', [MQT.HCONN, MQT.LONG, MQT.PCBD,MQT.HOBJ,MQT.PMD,MQT.PGMO,MQT.PLONG,MQT.PLONG]],
+      'MQINQ'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]],
+      'MQSET'  : ['void', [MQT.HCONN, MQT.HOBJ, MQT.LONG, mqLongArray, MQT.LONG, mqLongArray, MQT.LONG, 'pointer', MQT.PLONG,MQT.PLONG]],
+      'MQCRTMH' : ['void', [MQT.HCONN, MQT.PCMHO, MQT.PHMSG, MQT.PLONG, MQT.PLONG]],
+      'MQDLTMH' : ['void', [MQT.HCONN, MQT.PHMSG, MQT.PDMHO, MQT.PLONG, MQT.PLONG]],
+      'MQSETMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PSMPO, MQT.PCHARV, MQT.PPD, MQT.LONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG]],
+      'MQINQMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PIMPO, MQT.PCHARV, MQT.PPD, MQT.PLONG, MQT.LONG, 'pointer', MQT.PLONG, MQT.PLONG, MQT.PLONG]],
+      'MQDLTMP' : ['void', [MQT.HCONN, MQT.HMSG, MQT.PDMPO, MQT.PCHARV, MQT.PLONG, MQT.PLONG]],
+    });
     return null;
   } catch(err) {
     return err;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/mqi.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall" : "node postinstall.js"
+    "postinstall": "node postinstall.js"
   },
   "author": "Mark Taylor",
   "license": "Apache-2.0",
@@ -14,10 +14,10 @@
     "url": "https://github.com/ibm-messaging/mq-mqi-nodejs"
   },
   "dependencies": {
-    "unzip" : ">=0.1.11",
+    "unzip": ">=0.1.11",
     "ref": ">=1.3.0",
     "ref-array": ">=1.2.0",
     "ref-struct": ">=1.1.0",
-    "ffi": ">=2.2.0"
+    "fastcall": ">=0.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibmmq",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Bindings to call IBM MQ API",
   "main": "./lib/mqi.js",
   "scripts": {

--- a/samples/Dockerfile
+++ b/samples/Dockerfile
@@ -1,7 +1,7 @@
 
 # Using a "slim" base image ends up being about 100MB smaller than the regular ubuntu 
 #FROM ubuntu:16.04
-FROM debian:jessie-slim
+FROM node:slim
 
 # Set some parameters.
 ENV NODE_USER  app
@@ -26,16 +26,13 @@ COPY package.docker ${APP_DIR}/package.json
 
 # Update the base image and make sure we've installed basic capabilities
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl gcc g++ make \
-    && curl --silent -k --location https://deb.nodesource.com/setup_8.x | bash - \
-    && apt-get install -y  nodejs  \
-    && npm install -g npm \
+    && apt-get install -y --no-install-recommends python git cmake curl gcc g++ make \
 # Define the userid and set up the location for the program
    && groupadd -r ${NODE_GROUP} && useradd -r -m -g ${NODE_GROUP} ${NODE_USER} \
 # Now get all the prereq packages installed and cleanup the
 # pieces that are not needed after building the C interface pieces.
    && npm install \
-   && apt-get autoremove -y curl make gcc g++ python \
+   && apt-get autoremove -y cmake git curl make gcc g++ python \
    && apt-get purge -y \
    && rm -rf /var/lib/apt/lists/* \
    && chmod a+rx ${APP_DIR}/*

--- a/samples/package.docker
+++ b/samples/package.docker
@@ -6,6 +6,6 @@
   "author": "Mark Taylor",
   "license": "Apache-2.0",
   "dependencies": {
-    "ibmmq": ">=0.6.1"
+    "ibmmq": ">=0.8.0"
   }
 }


### PR DESCRIPTION
## What

Changed the module used to load a C Library in `node` from `ffi` to `fastcall` in order to support the newer versions of `node`

## How

Changed the dependencies in the `package.json` and adapted the code to use the `fastcall.ffi` instead of the classic `ffi`

## Testing

Use the library with node `v10.4.0`
