### PR TITLE
Fix tiny jsdoc issue, and provide own documentation for ConnSync

### DIFF
--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -766,8 +766,9 @@ function connx (jsqMgrName, jsCno, useAsync, cb) {
   }
 }
 
+
 /**
- * Conn, ConnSync - simpler version of Connx.
+ * Conn - simpler version of Connx.
  * The callback is passed object containing the hConn on success
  *
  * @param {String}
@@ -775,7 +776,7 @@ function connx (jsqMgrName, jsCno, useAsync, cb) {
  * @param {function}
  *        callback - optional for sync variant. Invoked for errors and
  *        with a reference to the qmgr connection.
- * @return {MQQueueManager) A reference to the connection
+ * @return {MQQueueManager} A reference to the connection
  * @throws {MQError}
  *         Container for MQRC and MQCC values
  * @throws {TypeError}
@@ -784,6 +785,22 @@ function connx (jsqMgrName, jsCno, useAsync, cb) {
 exports.Conn = function (jsqMgrName, cb) {
   exports.Connx(jsqMgrName,null,cb);
 };
+
+/**
+ * ConnSync - simpler version of ConnxSync.
+ * The callback is passed object containing the hConn on success
+ *
+ * @param {String}
+ *        qMgrName - the queue manager to connect to
+ * @param {function}
+ *        callback - optional for sync variant. Invoked for errors and
+ *        with a reference to the qmgr connection.
+ * @return {MQQueueManager} A reference to the connection
+ * @throws {MQError}
+ *         Container for MQRC and MQCC values
+ * @throws {TypeError}
+ *         When a parameter is of incorrect type
+ */
 exports.ConnSync = function (jsqMgrName, cb) {
   exports.ConnxSync(jsqMgrName,null,cb);
 };


### PR DESCRIPTION
Caused a problem when generating Typescript definitions

Please ensure all items are complete before opening.

- [X] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [X] You have completed the PR template below:

## What

Tiny change, just to documentation

## How

The issue caused the typescript definitions to default to 'any' for those methods

