### PR TITLE
Changes to allow resuming async Get after GetDone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+## 30 Oct 2019 : v0.9.10
+* Calling Get after a GetDone should now properly resume processing
+
 ## 28 Oct 2019 : v0.9.9
 * Changes to how the MQ C libraries are accessed.
   * Make the Redist Client libraries the default mechanism

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -328,7 +328,7 @@ function loadLib(dir,name) {
 // To make it practical to use local queue managers for some activity, this behaviour can be overridden via
 // an environment variable MQIJS_PREFER_INSTALLED_LIBRARY in which case the Redist directory is tried LAST.
 // We cannot use a tuning parameter as this function is executed as this module is loaded - the tuning
-// parm could only be set later.
+// parm could only be set later.scheduledGetLoop
 //
 // Note the use of '__dirname' which is a system-provided variable pointing at the directory
 // from which this module has been loaded.
@@ -1968,6 +1968,7 @@ function pollAllHConns () {
 
   if (contextMap.size == 0) {
     debugLog("No more hConns waiting for messages. Exiting getLoopFunction");
+    scheduledGetLoop = false;
     getLoop = null;
   }
 }
@@ -2282,7 +2283,6 @@ exports.GetDone = function(jsObject, cb) {
   }
 
   deleteUserContext(jsObject);
-  scheduledGetLoop = false;
 
   if (cb) {
     cb(null);

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -2240,6 +2240,7 @@ exports.GetDone = function(jsObject, cb) {
   }
 
   deleteUserContext(jsObject);
+  scheduledGetLoop = false;
 
   if (cb) {
     cb(null);

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -328,7 +328,7 @@ function loadLib(dir,name) {
 // To make it practical to use local queue managers for some activity, this behaviour can be overridden via
 // an environment variable MQIJS_PREFER_INSTALLED_LIBRARY in which case the Redist directory is tried LAST.
 // We cannot use a tuning parameter as this function is executed as this module is loaded - the tuning
-// parm could only be set later.scheduledGetLoop
+// parm could only be set later.
 //
 // Note the use of '__dirname' which is a system-provided variable pointing at the directory
 // from which this module has been loaded.

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -1968,9 +1968,13 @@ function pollAllHConns () {
 
   if (contextMap.size == 0) {
     debugLog("No more hConns waiting for messages. Exiting getLoopFunction");
-    scheduledGetLoop = false;
-    getLoop = null;
+    resetGetLoop();
   }
+}
+
+function resetGetLoop() {
+  scheduledGetLoop = false;
+  getLoop = null;
 }
 
 /*
@@ -2284,8 +2288,8 @@ exports.GetDone = function(jsObject, cb) {
 
   deleteUserContext(jsObject);
   if (contextMap.size == 0) {
-    debugLog("No more hConns waiting for messages. Resetting scheduleGetLoop");
-    scheduledGetLoop = false;
+    debugLog("No more hConns waiting for messages. Resetting Get loop");
+    resetGetLoop();
   }
   if (cb) {
     cb(null);

--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -2283,7 +2283,10 @@ exports.GetDone = function(jsObject, cb) {
   }
 
   deleteUserContext(jsObject);
-
+  if (contextMap.size == 0) {
+    debugLog("No more hConns waiting for messages. Resetting scheduleGetLoop");
+    scheduledGetLoop = false;
+  }
   if (cb) {
     cb(null);
   }

--- a/samples/amqsgetar.js
+++ b/samples/amqsgetar.js
@@ -1,0 +1,236 @@
+'use strict';
+/*
+  Copyright (c) IBM Corporation 2017
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+   Contributors:
+     Mark Taylor - Initial Contribution
+     Ryan Weland - Added resume processing test
+*/
+
+/*
+ * This is an example of a Node.js program to get single messages from an IBM MQ
+ * queue using an asynchronous method, stops processing, and then resumes processing.
+ *
+ * Based on amqsgeta.js
+ * 
+ * The queue and queue manager name can be given as parameters on the
+ * command line. Defaults are coded in the program.
+ *
+ * Each MQI call prints its success or failure.
+ */
+
+// Import the MQ package
+var mq = require('ibmmq');
+var MQC = mq.MQC; // Want to refer to this export directly for simplicity
+
+// Import any other packages needed
+var StringDecoder = require('string_decoder').StringDecoder;
+var decoder = new StringDecoder('utf8');
+
+// The default queue manager and queue to be used
+var qMgr = "QM1";
+var qName = "DEV.QUEUE.1";
+var msgId = null;
+
+// Some global variables
+var connectionHandle;
+var queueHandle;
+
+var waitInterval = 3; // max seconds to wait for a new message
+var ok = true;
+var exitCode = 0;
+var fetchedRecords = 0;
+
+/*
+ * Format any error messages
+ */
+function formatErr(err) {
+  if (err) {
+    ok = false;
+    return "MQ call failed at " + err.message;
+  } else {
+    return "MQ call successful";
+  }
+}
+
+function hexToBytes(hex) {
+  for (var bytes = [], c = 0; c < hex.length; c += 2)
+    bytes.push(parseInt(hex.substr(c, 2), 16));
+  return bytes;
+}
+
+
+/*
+ * Define which messages we want to get, and how.
+ */
+function getMessage() {
+  var md = new mq.MQMD();
+  var gmo = new mq.MQGMO();
+
+  gmo.Options = MQC.MQGMO_NO_SYNCPOINT |
+    MQC.MQGMO_WAIT |
+    MQC.MQGMO_CONVERT |
+    MQC.MQGMO_FAIL_IF_QUIESCING;
+  gmo.MatchOptions = MQC.MQMO_NONE;
+  gmo.WaitInterval = waitInterval * 1000; // 3 seconds
+
+  if (msgId != null) {
+    console.log("Setting Match Option for MsgId");
+    gmo.MatchOptions = MQC.MQMO_MATCH_MSG_ID;
+    md.MsgId = hexToBytes(msgId);
+  }
+
+  // Set up the callback handler to be invoked when there
+  // are any incoming messages. As this is a sample, I'm going
+  // to tune down the poll interval from default 10 seconds to 0.5s.
+  // Also tune the polling to only get one message per attempt to
+  // to facilitate single shot async
+  mq.setTuningParameters({ getLoopPollTimeMs: 500, maxConsecutiveGets: 1 });
+  mq.Get(queueHandle, md, gmo, getCB);
+
+}
+
+/*
+ * This function is the async callback. Parameters
+ * include the message descriptor and the buffer containing
+ * the message data.
+ */
+function getCB(err, hObj, gmo, md, buf, hConn) {
+  // If there is an error, prepare to exit by setting the ok flag to false.
+  if (err) {
+    if (err.mqrc == MQC.MQRC_NO_MSG_AVAILABLE) {
+      console.log("No more messages available.");
+    } else {
+      console.log(formatErr(err));
+      exitCode = 1;
+    }
+    ok = false;
+    // We don't need any more messages delivered, so cause the
+    // callback to be deleted after this one has completed.
+    mq.GetDone(hObj);
+  } else {
+    // Call done to inform the MQ to stop polling
+    mq.GetDone(hObj);
+    if (md.Format == "MQSTR") {
+      console.log("message <%s>", decoder.write(buf));
+    } else {
+      console.log("binary message: " + buf);
+    }
+
+    // Simulate a wait or other event which will cause to resume processing
+    // For the sake of the test, we will only do this once
+    if (++fetchedRecords < 2) {
+      setTimeout(() => {
+        // Resume processing second message
+        if (msgId2 != null) {
+          console.log("Setting Match Option for MsgId");
+          gmo.MatchOptions = MQC.MQMO_MATCH_MSG_ID;
+          md.MsgId = hexToBytes(msgId2);
+        }
+        mq.Get(hObj, md, gmo, getCB);
+      }, 2000 // Wait 2 seconds
+      )
+    }
+    else {
+      console.log("Done processing");
+      ok = false;
+    }
+  }
+}
+
+/*
+ * When we're done, close any queues and connections.
+ */
+function cleanup(hConn, hObj) {
+  mq.Close(hObj, 0, function (err) {
+    if (err) {
+      console.log(formatErr(err));
+    } else {
+      console.log("MQCLOSE successful");
+    }
+    mq.Disc(hConn, function (err) {
+      if (err) {
+        console.log(formatErr(err));
+      } else {
+        console.log("MQDISC successful");
+      }
+    });
+  });
+}
+
+/**************************************************************
+ * The program really starts here.
+ * Connect to the queue manager. If that works, the callback function
+ * opens the queue, and then we can start to retrieve messages.
+ */
+console.log("Sample AMQSGETA.JS start");
+
+// Get command line parameters
+var myArgs = process.argv.slice(2); // Remove redundant parms
+if (myArgs[0]) {
+  qName = myArgs[0];
+}
+if (myArgs[1]) {
+  qMgr = myArgs[1];
+}
+if (myArgs[2]) {
+  msgId = myArgs[2];
+}
+if (myArgs[3]) {
+  msgId2 = myArgs[3];
+}
+
+mq.setTuningParameters({ syncMQICompat: true });
+
+
+// Connect to the queue manager, including a callback function for
+// when it completes.
+mq.Conn(qMgr, function (err, hConn) {
+  if (err) {
+    console.log(formatErr(err));
+    ok = false;
+  } else {
+    console.log("MQCONN to %s successful ", qMgr);
+    connectionHandle = hConn;
+
+    // Define what we want to open, and how we want to open it.
+    var od = new mq.MQOD();
+    od.ObjectName = qName;
+    od.ObjectType = MQC.MQOT_Q;
+    var openOptions = MQC.MQOO_INPUT_AS_Q_DEF;
+    mq.Open(hConn, od, openOptions, function (err, hObj) {
+      queueHandle = hObj;
+      if (err) {
+        console.log(formatErr(err));
+      } else {
+        console.log("MQOPEN of %s successful", qName);
+        // And now we can ask for the messages to be delivered.
+        getMessage();
+      }
+    });
+  }
+});
+
+// We need to keep the program active so that the callbacks from the
+// message handler are processed. This is one way to do it. Use the
+// defined waitInterval with a bit extra added and look for the
+// current status. If not OK, then close everything down cleanly.
+setInterval(function () {
+  if (!ok) {
+    console.log("Exiting ...");
+    cleanup(connectionHandle, queueHandle);
+    process.exit(exitCode);
+  }
+}, (waitInterval + 2) * 1000);

--- a/tests/putgetr
+++ b/tests/putgetr
@@ -1,0 +1,22 @@
+# This test puts a message and then uses the msgId to retrieve the same message
+#
+# amqsput prints the msgid as a hex string, which amqsgeta will then convert back to 
+# a byte array
+#
+
+r="`pwd`/.."
+cd $r/samples
+
+
+# Note the format that amqsput writes the MsgId. Save to a temp file for extraction
+# so we still see all the other messages printed by the program
+node amqsput.js | tee /tmp/nodetest.out
+id=`grep MsgId /tmp/nodetest.out | cut -f2 -d:`
+
+# Put a second message
+node amqsput.js | tee /tmp/nodetest.out
+id2=`grep MsgId /tmp/nodetest.out | cut -f2 -d:`
+
+# Then pass it as a parameter to the getter
+node amqsgetar.js DEV.QUEUE.1 QM1 $id $id2
+


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

Once calling GetDone async processing could not be resumed with a subsequent Get call due to scheduledGetLoop still being true. This would cause the application to terminate unexpectedly when attempting to fetch messages.

## How

Added change to existing async logic to also reset the `scheduledGetLoop` variable when it is detected there are no longer hConn's in the contextMap.

## Testing

Test `putgetr` and subsequent code file `amqsgetar.js` were created to test this situation. Two messages will be put onto the test queue, and then read off async with a pause in between reads.

## Issues

None
