### PR TITLE
fix(install): change macos toolkit name

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -147,7 +147,7 @@ if (currentPlatform === 'win32') {
 //
 //  dir=macDir
 //  title="IBM MacOS Toolkit for Developers"
-//  file="IBM-MQ-Toolkit-Mac-x64-" + macVrmf + ".tar.gz"
+//  file=macVrmf + "-IBM-MQ-Toolkit-MacX64" + ".tar.gz"
 //  unpackCommand="mkdir -p " +  newBaseDir + " && tar -xvzf " + file + " -C " + newBaseDir;
 //  unwantedDirs=[ "samp", "bin","inc","java", "gskit8/lib", ".github" ];
 } else {


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

MacOS Toolkit filename was changed

## How

I tried installing the toolkit using postinstall.js, but the filename had the wrong name. Then, I just updated the filename to current name.
