### PR TITLE
feat: enable redist download on darwing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+## 17 Mar 2021 : v0.9.17
+* Allow install redist files in darwin platform setting new environment variable
+
 ## 02 Dec 2020 : v0.9.16
 * Update for MQ 9.2.1
 * Allow override of VRM and fixpack levels

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ set `MQIJS_FIXPACK=1` before running `npm install`. Once newer CD levels are ava
 postinstall script will point at those instead by default.
 
 
+
 ### MacOS
 The MQ client package for MacOS can be found at
 [this site](http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/mactoolkit).
@@ -235,6 +236,11 @@ that tree before running the program.
 For example
 
 `export DYLD_LIBRARY_PATH=/opt/mqm/lib64`
+
+
+If you want to download the redist binaries without 
+modifying postinstall.js after executing `npm install`, you can set the env var `MQIJS_DARWIN_REDIST` to enable it.
+
 
 #### Errors and warnings during build
 If you get an error message such as "gyp: No Xcode or CLT version detected" while

--- a/postinstall.js
+++ b/postinstall.js
@@ -18,6 +18,10 @@ var macDir=baseDir+"/mactoolkit";
 // This is the version (VRM) of MQ associated with this level of package
 var vrm="9.2.1";
 
+// Allow installing it on darwin with an environment variable
+// so we do not need to do the post install stuff modifying node_modules/ibmmq stuff
+var downloadInDarwin=process.env['MQIJS_DARWIN_REDIST'];
+
 // Allow overriding the VRM - but you need to be careful as this package
 // may depend on MQI features in the listed version. Must be given in the
 // same format eg "1.2.3". Note that IBM keeps a limited set of versions for
@@ -178,16 +182,16 @@ if (currentPlatform === 'win32') {
   file=file+"LinuxX64.tar.gz";
   unpackCommand="mkdir -p " +  newBaseDir + " && tar -xvzf " + file + " -C " + newBaseDir;
   unwantedDirs=[ "samp", "bin","inc","java", "gskit8/lib", ".github" ];
-//} else if (currentPlatform === 'darwin'){
+} else if (currentPlatform === 'darwin' && downloadInDarwin){
 //  The MacOS client for MQ is released under a different license - 'Developers' not
 //  'Redistributable' - so we will not try to automatically download it. But all the
 //  pieces are in this script to enable it at some point.
-//
-//  dir=macDir
-//  title="IBM MacOS Toolkit for Developers"
-//  file=vrmf + "-IBM-MQ-Toolkit-MacX64" + ".tar.gz"
-//  unpackCommand="mkdir -p " +  newBaseDir + " && tar -xvzf " + file + " -C " + newBaseDir;
-//  unwantedDirs=[ "samp", "bin","inc","java", "gskit8/lib", ".github" ];
+
+ dir=macDir
+ title="IBM MacOS Toolkit for Developers"
+ file=vrmf + "-IBM-MQ-Toolkit-MacX64" + ".tar.gz"
+ unpackCommand="mkdir -p " +  newBaseDir + " && tar -xvzf " + file + " -C " + newBaseDir;
+ unwantedDirs=[ "samp", "bin","inc","java", "gskit8/lib", ".github" ];
 } else {
   console.log("No redistributable client package available for this platform.");
   console.log("If an MQ Client library exists for the platform, install it manually.");


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [x] You have added tests for any code changes
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What
Enable download the redist files with the post-install script on Darwin platforms

## How
A new environment variable 'MQIJS_DARWIN_REDIST' is available to enable it.

## Testing
Install the package on a darwin environment and check if the library is downloaded inside node_modules/ibmmq

## Issues
No issue related