### PR TITLE
fix outgoing MQRFH2 #125

### DIFF
--- a/lib/mqrfh2.js
+++ b/lib/mqrfh2.js
@@ -102,7 +102,7 @@ var _MQRFH2ffi_t = StructType({
 function _newMQRFH2ffi() {
   var rfh2 = new _MQRFH2ffi_t();
 
-  u.setMQIString(rfh2.StrucId,"RFH2 ");
+  u.setMQIString(rfh2.StrucId,"RFH");
   rfh2.Version        = 2; // We will always work with this version
   rfh2.StrucLength    = MQC.MQRFH_STRUC_LENGTH_FIXED_2;
   rfh2.Encoding       = MQC.MQENC_NATIVE;
@@ -122,10 +122,12 @@ function _copyRFH2toC(jsRFH2) {
 
   var mqRFH2 = _newMQRFH2ffi();
 
+  mqRFH2.StrucLength = jsRFH2.StrucLength;
   mqRFH2.Encoding = jsRFH2.Encoding;
   mqRFH2.CodedCharSetId = jsRFH2.CodedCharSetId;
-  mqRFH2.Flags          = jsRFH2.Flags;
   u.setMQIString(mqRFH2.Format, jsRFH2.Format);
+  mqRFH2.Flags = jsRFH2.Flags;
+  mqRFH2.NameValueCCSID = jsRFH2.NameValueCCSID;
 
   return mqRFH2;
 }


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [X] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [X] You have completed the PR template below:

## What

Fixed `rfh2.StrucId` and added two extra fields to `_copyRFH2toC`

## How

`u.setMQIString(rfh2.StrucId,"RFH");` without trailing space because `setMQIString` already can pad strings with spaces and without "2" because I checked a message sent from Java with Wireshark

## Testing

Tried to put a message to a queue, and checked with Wireshark, that the message is well formed.
```js
const msg = 'SOME BODY'
const usr = '<usr><SomeExtraHeader>abc123</SomeExtraHeader></usr>';
const usrBuffer = Buffer.from(usr.padEnd(usr.length + (4 - usr.length % 4)));
const usrLength = Buffer.alloc(4);
usrLength.writeInt32LE(usrBuffer.length); // LE because of rfh2.Encoding
rfh2.StrucLength = rfh2.StrucLength + 4 + usrBuffer.length;
msg = Buffer.concat([rfh2.getBuffer(), usrLength, usrBuffer, Buffer.from(msg)]);
```

## Issues

https://github.com/ibm-messaging/mq-mqi-nodejs/issues/125