### PR TITLE
Always check if the GetLoop needs to be reset

### DIFF
--- a/lib/mqi.js
+++ b/lib/mqi.js
@@ -2316,9 +2316,10 @@ exports.GetDone = function(jsObject, cb) {
     err = new MQError(MQC.MQCC_FAILED,MQC.MQRC_HOBJ_ERROR,"GetDone");
   } else {
     deleteUserContext(jsObject);
-    if (contextMap.size == 0) {
-      resetGetLoop();
-    }
+  }
+
+  if (contextMap.size == 0) {
+    resetGetLoop();
   }
 
   if (cb) {


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

When calling `GetDone` always check if the `GetLoop` needs to be reset. 

## How

If the server is hard closed we get the following error:
`GET: MQCC = MQCC_FAILED [2] MQRC = MQRC_CONNECTION_BROKEN [2009]`

When trying to gracefully handle the reconnection and then restart the `Get`, the poll is never restarted.

The log of a failure to restart the polling is here (I added comments and tried to break the log up for easy reading):
https://gist.github.com/scagood/17d390765af4746dded9c1ed22b45dfa#file-ibmmq-not-resuming-log

## Testing

After patching my local node_modules everything resumed as expected:
https://gist.github.com/scagood/17d390765af4746dded9c1ed22b45dfa#file-ibmmq-resuming-log
