### PR TITLE
Make postinstall.js exit with code 1 on error

### DIFF
--- a/postinstall.js
+++ b/postinstall.js
@@ -67,15 +67,13 @@ function cleanup() {
     }
   } catch(err) {
   }
-
-  // Always exit OK, even after an error so the rest of the install succeeds.
-  process.exit(0);
 }
 
 function printError(err) {
   console.error("Error occurred downloading " + title + ": " + err.message);
   console.error("You will need to manually install it.");
   cleanup();
+  process.exit(1);
 }
 
 // Equivalent of "rm -rf"
@@ -87,7 +85,7 @@ function removeDirRecursive(d) {
                 removeDirRecursive(ePath);
             } else {
                 // Keep runmqsc as it might be useful for creating CCDTs locally,
-                // particularly in a containerised runtime. And runmqakm might be 
+                // particularly in a containerised runtime. And runmqakm might be
 		// needed if you want to manage certs locally rather than outside
 		// a container.
                 if (!e.match(/runmqsc/) && !e.match(/runmqakm/))
@@ -143,6 +141,7 @@ function removeUnneeded() {
   }
 
   cleanup();
+  process.exit(0);
 }
 
 
@@ -170,7 +169,7 @@ if (currentPlatform === 'win32') {
   unwantedDirs=[ "samp", "bin","inc","java", "gskit8/lib", ".github" ];
 //} else if (currentPlatform === 'darwin'){
 //  The MacOS client for MQ is released under a different license - 'Developers' not
-//  'Redistributable' - so we should not try to automatically download it. 
+//  'Redistributable' - so we should not try to automatically download it.
 //
 //  As another issue, the MacOS client is now being delivered in signed pkg format, not zip. So this won't
 //  work. I'm leaving this bit of code in just to remind us of the directory from which


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [IBM Contributor License Agreement](https://github.com/ibm-messaging/mq-mqi-nodejs/CLA.md)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

Make postinstall.js exit with code 1 on error, thus preventing a "successful" install.

## Why

Occasionally we get "successfully" built docker images that just completely lack the queue client (this seems to happen in batches).

Here are a couple of built images:
![image](https://user-images.githubusercontent.com/2230835/181499840-a8161324-dee5-4b2f-b8d5-37d4a56a6659.png)
You can see that a couple of them are remarkably small compared to the rest.

This would not be an issue if it were not for the fact that said images are connected to a Continuous Deployment pipeline, causing errors like this to occasionally appear in my test environment:
![image](https://user-images.githubusercontent.com/2230835/181500427-acf69907-67b5-4c8d-86d3-e199b89cc8df.png)

## Testing

```bash
$ docker run -it --entrypoint=/bin/bash node:16.16

# From here the entire work flow is in the container

$ npm install --ignore-scripts ibmmq
<snip>

# Make changes in docker image
$ nano node_modules/ibmmq/postinstall.js

# First a clean success
$ (cd node_modules/ibmmq; node postinstall.js)
Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.0.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.0.0-IBM-MQC-Redist-LinuxX64.tar.gz
Unpacking libraries...
Removing 9.3.0.0-IBM-MQC-Redist-LinuxX64.tar.gz

# Check the exit code
$ echo $?
0

# Reset state
$ rm -rf node_modules/ibmmq/redist/
# Break the download
$ echo '127.0.0.1 public.dhe.ibm.com' >> /etc/hosts

# Now a failed download
$ (cd node_modules/ibmmq; node postinstall.js)
Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.0.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.0.0-IBM-MQC-Redist-LinuxX64.tar.gz
Error occurred downloading IBM MQ Redistributable C Client: connect ECONNREFUSED 127.0.0.1:443
You will need to manually install it.
Removing 9.3.0.0-IBM-MQC-Redist-LinuxX64.tar.gz

# Check the exit code
$ echo $?
1
```
