### PR TITLE
Respect proxy settings in postinstall

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # Changelog
 Newest updates are at the top of this file.
 
+## 21 Jul 2023: v2.0.2
+* Updated `postinstall` to support http proxy environment variables 
+
 ## 05 Jul 2023: v2.0.1 
 * Added LinuxARM definitions
 * Fix TLS channels not using correct structure version

--- a/README.md
+++ b/README.md
@@ -258,6 +258,28 @@ This package cannot currently run on z/OS as the prerequisite MQ libraries are n
 the same way as other platforms. However, it might be possible in future to add that platform as there
 are no dependencies on 3rd party non-core components (eg lib-ffi) that would never be available on z/OS. 
 
+### Downloading behind a proxy
+
+Downloading the Redistributable C Client libraries behind a proxy is supported. Use the environment 
+variables `https_proxy` and `no_proxy` to control proxy behaviour.
+
+For example, the following command will use a proxy server at `http://localhost:8080` to download 
+the redistributable libraries:
+
+```
+% HTTPS_PROXY=http://localhost:8080 npm install
+```
+
+You can disable this behaviour by adding `public.dhe.ibm.com` to the `NO_PROXY`
+environment variable. The following command will not use the proxy to download
+the redistributable libraries:
+
+```
+% NO_PROXY="public.dhe.ibm.com" HTTPS_PROXY=http://localhost:8080 npm install
+```
+
+Alternatively, you can simply `unset HTTPS_PROXY`.
+
 ## Sample applications
 See the samples [README](samples/README.md) file for more information about the sample programs.
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "gypfile": true,
   "dependencies": {
     "node-addon-api": "^7.0.0",
-    "node-gyp-build": "^4.6.0"
+    "node-gyp-build": "^4.6.0",
+    "proxy-agent": "^6.3.0"
   },
   "engines": {
     "node": ">=16.0"


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-mqi-nodejs/DCO1.1.txt)
  - Note: proxy-agent is licensed under MIT, which is compatible with this projects' Apache 2.0.
- [ ] You have added tests for any code changes
  - Note: `postinstall.js` does not have associated test files. I have not changed the structure of this code to make it testable, as that would require more work than introducing the wanted behaviour.
  - I have, however, performed manual testing as described below.
- [x] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

Add support for the `postinstall.js` script to support proxy settings. Updated `CHANGES.md` and `README.md`.

The `postinstall.js` file was automatically formatted using the Eslint settings for the repository. This happens automatically for me in my editor. If you prefer I revert that styling I can look into it.

## How

Use [proxy-agent](https://www.npmjs.com/package/proxy-agent) to configure the HTTP agent when making requests. `proxy-agent` respects the typical environment variables `http_proxy`, `https_proxy` and `no_proxy`.

Originally I went down the path of introducing this behaviour without a library. As it turns out, handling all the interactions for these environment variables is rather complex, so it seemed a better idea to not roll my own functionality.

## Testing

Manual testing. The `postinstall.js` script was not in a state to support automated testing before introducing these changes.

### Test type: no_proxy is not set.

Typically expecting to see that `http_proxy` has no effect, and `https_proxy` does.

| Expected Behavior | As Expected? | no_proxy | http_proxy            | HTTP_PROXY            | https_proxy           | HTTPS_PROXY           |
| ----------------- | ------------ | -------- | --------------------- | --------------------- | --------------------- | --------------------- |
| Pull from IBM     | Yes          | unset    | unset                 | unset                 | unset                 | unset                 |
| Pull from IBM     | Yes          | unset    | http://localhost:3128 | unset                 | unset                 | unset                 |
| Pull from IBM     | Yes          | unset    | unset                 | http://localhost:3128 | unset                 | unset                 |
| Pull from Proxy   | Yes          | unset    | unset                 | unset                 | http://localhost:3128 | unset                 |
| Pull from Proxy   | Yes          | unset    | unset                 | unset                 | unset                 | http://localhost:3128 |

### Test type: no_proxy is set with config not containing IBM domain.

Typically expecting to see that `http_proxy` has no effect, and `https_proxy` does.

| Expected Behavior | As Expected? | no_proxy               | http_proxy            | HTTP_PROXY            | https_proxy           | HTTPS_PROXY           |
| ----------------- | ------------ | ---------------------- | --------------------- | --------------------- | --------------------- | --------------------- |
| Pull from IBM     | Yes          | `google.com,yahoo.com` | http://localhost:3128 | unset                 | unset                 | unset                 |
| Pull from IBM     | Yes          | `google.com,yahoo.com` | unset                 | http://localhost:3128 | unset                 | unset                 |
| Pull from Proxy   | Yes          | `google.com,yahoo.com` | unset                 | unset                 | http://localhost:3128 | unset                 |
| Pull from Proxy   | Yes          | `google.com,yahoo.com` | unset                 | unset                 | unset                 | http://localhost:3128 |

### Test type: no_proxy is set with config containing IBM domain.

Typically expecting to see that `http_proxy` and `https_proxy` have no effect as they are overridden by `no_proxy`.

| Expected Behavior | As Expected? | no_proxy               | http_proxy            | HTTP_PROXY            | https_proxy           | HTTPS_PROXY           |
| ----------------- | ------------ | ---------------------- | --------------------- | --------------------- | --------------------- | --------------------- |
| Pull from IBM     | Yes          | `google.com,*.ibm.com` | http://localhost:3128 | unset                 | unset                 | unset                 |
| Pull from IBM     | Yes          | `google.com,*.ibm.com` | unset                 | http://localhost:3128 | unset                 | unset                 |
| Pull from IBM     | Yes          | `google.com,*.ibm.com` | unset                 | unset                 | http://localhost:3128 | unset                 |
| Pull from IBM     | Yes          | `google.com,*.ibm.com` | unset                 | unset                 | unset                 | http://localhost:3128 |

### Test Logs

Check the `proxy-agent` output lines to see whether the proxy is configured for each command.

<details>
  <summary>Logs</summary>
  <p>
[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +6ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent HTTP_PROXY=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent http_proxy=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent HTTPS_PROXY=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Request URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms
  proxy-agent Proxy URL: 'http://localhost:3128' +0ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent https_proxy=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Request URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +6ms
  proxy-agent Proxy URL: 'http://localhost:3128' +0ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,yahoo.com" HTTP_PROXY=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,yahoo.com" http_proxy=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,yahoo.com" HTTPS_PROXY=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Request URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms
  proxy-agent Proxy URL: 'http://localhost:3128' +1ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,yahoo.com" https_proxy=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Request URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms
  proxy-agent Proxy URL: 'http://localhost:3128' +0ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,*.ibm.com" HTTP_PROXY=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,*.ibm.com" http_proxy=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,*.ibm.com" HTTPS_PROXY=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms

---

[adamtuechler] ~/src/advmtue/mq-mqi-nodejs % DEBUG=proxy-agent no_proxy="google.com,*.ibm.com" https_proxy=http://localhost:3128 npm run postinstall

> ibmmq@2.0.1 postinstall
> node postinstall.js

Downloading IBM MQ Redistributable C Client runtime libraries - version 9.3.3.0
Getting https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz
  proxy-agent Creating new ProxyAgent instance: undefined +0ms
  proxy-agent Proxy not enabled for URL: 'https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.3.0-IBM-MQC-Redist-LinuxX64.tar.gz' +5ms
  </p>
</details>

## Issues

[postinstall.js fails while running behind proxy #65](https://github.com/ibm-messaging/mq-mqi-nodejs/issues/65)