### PR TITLE
Fix value returned from MQRFH2.getBuffer()

### DIFF
--- a/lib/mqstruc.js
+++ b/lib/mqstruc.js
@@ -209,7 +209,7 @@ exports.MQRFH2.prototype.getBuffer = function () {
     writeMQLONG(rfh2, offset, this.Flags);
     writeMQLONG(rfh2, offset, this.NameValueCCSID);
 
-    return;
+    return rfh2;
 };
 
 /**


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-mqi-nodejs/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

Missing return value was added to MQRFH2.getBuffer() method

## How

Variable was added to the return statement

## Testing
This code now prints buffer and not an undefined:
```
const mq = require('ibmmq');
const {MQC} = require("ibmmq");

var rfh2 = new mq.MQRFH2();
rfh2.Format = MQC.MQFMT_STRING;
rfh2.Encoding = MQC.MQENC_NATIVE;
rfh2.CodedCharSetId = MQC.MQCCSI_INHERIT;

console.log(rfh2.getBuffer());
```

## Issues
No github issues on this problem were there when I last checked
