### PR TITLE
Update types for MRHF2 get properties methods

### DIFF
--- a/types/mqrfh2.d.ts
+++ b/types/mqrfh2.d.ts
@@ -38,8 +38,20 @@ declare module "ibmmq" {
     static getHeader: (buf: Buffer) => MQRFH2;
 
     /**
-     * getProperties returns the XML-like string. Input is the already-parsed
-     * header structure and the entire message body (including the unparsed header)
+     * getAllProperties returns the XML-like strings as an array.
+     * Input is the already-parsed header structure and the entire message
+     * body (including the unparsed header). Most likely, only propsArray[0]
+     * is ever populated.
+     */
+    static getAllProperties(hdr: MQRFH2, buf: Buffer): string[];
+
+    /**
+     * @deprecated since version 2.1.0. Use of {@link getAllProperties} is preferred.
+     *
+     * getProperties returns all of the namevalue data elements in the RFH2 as a single string.
+     * This was the original behaviour provided, and is fine if there is only a single element in the RFH2
+     * structure. Preferred, however, is the newer and more general getAllProperties which returns
+     * the elements as separate array entries.
      */
     static getProperties: (hdr: MQRFH2, buf: Buffer) => string;
   }


### PR DESCRIPTION
Please ensure all items are complete before opening.

- [x] Tick to sign-off your agreement to the [Developer's Certificate of Origin](https://github.com/ibm-messaging/mq-mqi-nodejs/DCO1.1.txt)
- [ ] You have added tests for any code changes
- [ ] You have updated the [CHANGES.md](https://github.com/ibm-messaging/mq-mqi-nodejs/CHANGES.md)
- [x] You have completed the PR template below:

## What

Docstrings from TypeScript [types of MQRFH2](https://github.com/ibm-messaging/mq-mqi-nodejs/blob/527722fc06484450d40a83e13fdaa7db8722afb5/types/mqrfh2.d.ts) class didn't match the JSDocs from [js.code](https://github.com/ibm-messaging/mq-mqi-nodejs/blob/527722fc06484450d40a83e13fdaa7db8722afb5/lib/mqstruc.js#L263)

Updated MQRFH2 class .d.ts:
- static getProperties(): updated docstring to match JSDoc from source file
- static getAllProperties(): added, wasn't there before

## How

Updated the mqrfh2.d.ts manually, pasting the content from JSDocs from [js.code](https://github.com/ibm-messaging/mq-mqi-nodejs/blob/527722fc06484450d40a83e13fdaa7db8722afb5/lib/mqstruc.js#L263). Not sure if you have a more "automated" script somewhere, couldn't find it.

## Testing

Check InteliSense descriptions compared to JSDocs

## Issues

#200 
